### PR TITLE
feat(web): add link at Next.js 13.4

### DIFF
--- a/issues/2023-05.md
+++ b/issues/2023-05.md
@@ -24,7 +24,7 @@
 ### [AWS Amplify로 PR 미리보기](https://velog.io/@heka1024/AWS-Amplify%EB%A1%9C-PR-%EB%AF%B8%EB%A6%AC%EB%B3%B4%EA%B8%B0)
 - AWS의 서비스 중 하나인 Amplify를 사용하여 프론트엔드 개발자가 PR마다 preview build를 확인할 수 있게 하는 방법에 대해 소개합니다.
 
-### [Next.js 13.4]
+### [Next.js 13.4](https://nextjs.org/blog/next-13-4)
 - Next js 13.4가 릴리즈 되었습니다.
 - AppRouter가 stable로 업데이트됩니다.
 - 새로 구성하는 프로젝트는 AppRouter를 사용하길 권장합니다.


### PR DESCRIPTION
Next.js 13.4 아티클에 링크가 누락된 것으로 보여 추가했습니다.